### PR TITLE
filesystem: stabilize mount point detection

### DIFF
--- a/filesystem/btrfs.go
+++ b/filesystem/btrfs.go
@@ -62,26 +62,22 @@ func (fs btrfs) Mount(target string, readonly bool) error {
 	return Mount(fs.device, target, "btrfs", btrfsMountOpts, readonly)
 }
 
-func (fs btrfs) Unmount() error {
-	return Unmount(fs.device)
+func (fs btrfs) Unmount(target string) error {
+	return Unmount(fs.device, target)
 }
 
-func (fs btrfs) Resize() error {
-	d, err := MountedDir(fs.device)
-	if err != nil {
-		return err
-	}
-	out, err := exec.Command(cmdBtrfs, "filesystem", "resize", "max", d).CombinedOutput()
+func (fs btrfs) Resize(target string) error {
+	out, err := exec.Command(cmdBtrfs, "filesystem", "resize", "max", target).CombinedOutput()
 	if err != nil {
 		out := string(out)
 		log.Error("failed to resize btrfs filesystem", map[string]interface{}{
 			"device":    fs.device,
-			"directory": d,
+			"directory": target,
 			log.FnError: err,
 			"output":    out,
 		})
 		return fmt.Errorf("failed to resize btrfs filesystem: device=%s, directory=%s, err=%v, output=%s",
-			fs.device, d, err, out)
+			fs.device, target, err, out)
 	}
 
 	return nil

--- a/filesystem/ext4.go
+++ b/filesystem/ext4.go
@@ -59,11 +59,11 @@ func (fs ext4) Mount(target string, readonly bool) error {
 	return Mount(fs.device, target, "ext4", ext4MountOpts, readonly)
 }
 
-func (fs ext4) Unmount() error {
-	return Unmount(fs.device)
+func (fs ext4) Unmount(target string) error {
+	return Unmount(fs.device, target)
 }
 
-func (fs ext4) Resize() error {
+func (fs ext4) Resize(_ string) error {
 	out, err := exec.Command(cmdResize2fs, fs.device).CombinedOutput()
 	if err != nil {
 		out := string(out)

--- a/filesystem/interface.go
+++ b/filesystem/interface.go
@@ -17,9 +17,6 @@ var (
 	// ErrFilesystemExists is an error returned when the device has a filesystem.
 	ErrFilesystemExists = errors.New("filesystem exists")
 
-	// ErrNotMounted is an error returned when the device is not mounted.
-	ErrNotMounted = errors.New("not mounted")
-
 	fsTypeMap = make(map[string]func(device string) Filesystem)
 )
 
@@ -33,17 +30,19 @@ type Filesystem interface {
 	Mkfs() error
 
 	// Mount mounts the filesystem onto the target directory.
+	// target directory must exist.
 	// If device is mounted on target, this returns nil.
 	// If readonly is true, the filesystem will be mounted as read-only.
 	Mount(target string, readonly bool) error
 
 	// Unmount unmounts if device is mounted.
+	// target directory must exist.
 	// If not mounted, this does nothing.
-	Unmount() error
+	Unmount(target string) error
 
 	// Resize resizes the filesystem to match the size of the underlying block device.
 	// It should be called while the filesystem is mounted.
-	Resize() error
+	Resize(target string) error
 }
 
 // New returns a Filesystem if fsType is supported.

--- a/filesystem/interface_test.go
+++ b/filesystem/interface_test.go
@@ -101,35 +101,20 @@ func testFilesystem(t *testing.T, fsType string) {
 		t.Fatal(err)
 	}
 	defer os.Remove(d)
-	badd, err := ioutil.TempDir("", "test-mount")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(badd)
 
-	if err := fs.Unmount(); err != nil {
+	if err := fs.Unmount(d); err != nil {
 		t.Error(err)
 	}
 
-	if _, err := MountedDir(dev); err != ErrNotMounted {
-		t.Error(`err != ErrNotMounted`, err)
-	}
 	if err := fs.Mount(d, false); err != nil {
 		t.Fatal(err)
 	}
 
-	d2, err := MountedDir(dev)
-	if err != nil {
+	if err := exec.Command("mountpoint", "-q", d).Run(); err != nil {
 		t.Error(err)
-	}
-	if d != d2 {
-		t.Errorf(`device is mounted on unexpected directory %s while it should be %s`, d2, d)
 	}
 	if err := fs.Mount(d, false); err != nil {
 		t.Error("mount on the same directory should succeed", err)
-	}
-	if err := fs.Mount(badd, false); err == nil {
-		t.Error("mount on another directory should fail")
 	}
 
 	// file write test
@@ -148,7 +133,7 @@ func testFilesystem(t *testing.T, fsType string) {
 	if err := exec.Command("losetup", "-c", dev).Run(); err != nil {
 		t.Fatal(err)
 	}
-	if err := fs.Resize(); err != nil {
+	if err := fs.Resize(d); err != nil {
 		t.Fatal(err)
 	}
 	if err := unix.Statfs(d, &stfs); err != nil {
@@ -160,7 +145,7 @@ func testFilesystem(t *testing.T, fsType string) {
 	}
 	t.Log("newSize:", newSize)
 
-	if err := fs.Unmount(); err != nil {
+	if err := fs.Unmount(d); err != nil {
 		t.Error(err)
 	}
 
@@ -172,7 +157,7 @@ func testFilesystem(t *testing.T, fsType string) {
 	if err == nil {
 		t.Error("os.Create should fail")
 	}
-	if err := fs.Unmount(); err != nil {
+	if err := fs.Unmount(d); err != nil {
 		t.Error(err)
 	}
 }

--- a/filesystem/xfs.go
+++ b/filesystem/xfs.go
@@ -59,26 +59,22 @@ func (fs xfs) Mount(target string, readonly bool) error {
 	return Mount(fs.device, target, "xfs", xfsMountOpts, readonly)
 }
 
-func (fs xfs) Unmount() error {
-	return Unmount(fs.device)
+func (fs xfs) Unmount(target string) error {
+	return Unmount(fs.device, target)
 }
 
-func (fs xfs) Resize() error {
-	d, err := MountedDir(fs.device)
-	if err != nil {
-		return err
-	}
-	out, err := exec.Command(cmdXFSGrowFS, d).CombinedOutput()
+func (fs xfs) Resize(target string) error {
+	out, err := exec.Command(cmdXFSGrowFS, target).CombinedOutput()
 	if err != nil {
 		out := string(out)
 		log.Error("failed to resize xfs filesystem", map[string]interface{}{
 			"device":    fs.device,
-			"directory": d,
+			"directory": target,
 			log.FnError: err,
 			"output":    out,
 		})
 		return fmt.Errorf("failed to resize xfs filesystem: device=%s, directory=%s, err=%v, output=%s",
-			fs.device, d, err, out)
+			fs.device, target, err, out)
 	}
 
 	return nil


### PR DESCRIPTION
The device filepath appearing in /proc/mounts can be any file
in the filesystem if the file is the device file having the
same major/minor device numbers.