### PR TITLE
Kuberntes 1.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ GO_FILES=$(shell find -name '*.go' -not -name '*_test.go')
 BUILD_TARGET=hypertopolvm
 
 # CSI sidecard containers
-EXTERNAL_PROVISIONER_VERSION=1.1.1
+EXTERNAL_PROVISIONER_VERSION=1.3.0
 NODE_DRIVER_REGISTRAR_VERSION=1.1.0
-EXTERNAL_ATTACHER_VERSION=1.1.1
+EXTERNAL_ATTACHER_VERSION=1.2.1
 CSI_SIDECARS = \
 	external-provisioner \
 	node-driver-registrar \

--- a/deploy/manifests/crd.yaml
+++ b/deploy/manifests/crd.yaml
@@ -9,6 +9,7 @@ spec:
   names:
     kind: LogicalVolume
     plural: logicalvolumes
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}

--- a/deploy/manifests/crd.yaml
+++ b/deploy/manifests/crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/deploy/manifests/crd.yaml
+++ b/deploy/manifests/crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/deploy/manifests/mutatingwebhooks.yaml
+++ b/deploy/manifests/mutatingwebhooks.yaml
@@ -101,6 +101,7 @@ webhooks:
         namespace: topolvm-system
         name: topolvm-hook
         path: /mutate
+    matchPolicy: Equivalent
     rules:
       - operations: ["CREATE"]
         apiGroups: [""]

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -3,7 +3,7 @@ GOFLAGS=-mod=vendor
 export GOFLAGS
 GINKGO=$(GOPATH)/bin/ginkgo
 KUBECTL=/usr/local/bin/kubectl
-KUBERNETES_VERSION=1.14.3
+KUBERNETES_VERSION=1.15.0
 
 GO_FILES := $(shell find .. -path ../vendor -prune -o -path ../e2e -prune -o -name '*.go' -print)
 CA_FILES=./certs/ca.csr ./certs/ca.pem ./certs/ca-key.pem

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -3,7 +3,8 @@ GOFLAGS=-mod=vendor
 export GOFLAGS
 GINKGO=$(GOPATH)/bin/ginkgo
 KUBECTL=/usr/local/bin/kubectl
-KUBERNETES_VERSION=1.15.0
+KUBERNETES_VERSION=1.15.3
+KIND_VERSION=0.5.1
 
 GO_FILES := $(shell find .. -path ../vendor -prune -o -path ../e2e -prune -o -name '*.go' -print)
 CA_FILES=./certs/ca.csr ./certs/ca.pem ./certs/ca-key.pem
@@ -111,7 +112,7 @@ setup: $(KUBECTL)
 	go install github.com/cloudflare/cfssl/cmd/cfssl
 	go install github.com/cloudflare/cfssl/cmd/cfssljson
 	go install github.com/onsi/ginkgo/ginkgo
-	cd /tmp; env GOFLAGS= GO111MODULE=on go get sigs.k8s.io/kind@v0.4.0
+	cd /tmp; env GOFLAGS= GO111MODULE=on go get sigs.k8s.io/kind@v$(KIND_VERSION)
 	$(SUDO) apt-get update
 	$(SUDO) apt-get install -y lvm2 xfsprogs
 	if apt-cache show btrfs-progs; then \

--- a/e2e/csi.yml
+++ b/e2e/csi.yml
@@ -209,7 +209,7 @@ spec:
               mountPath: /run/topolvm
 
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.1.0
+          image: quay.io/k8scsi/csi-provisioner:v1.3.0
           imagePullPolicy: "IfNotPresent"
           args:
             - "--csi-address=/run/topolvm/csi-topolvm.sock"
@@ -219,7 +219,7 @@ spec:
               mountPath: /run/topolvm
 
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.1.1
+          image: quay.io/k8scsi/csi-attacher:v1.2.1
           imagePullPolicy: "IfNotPresent"
           args:
             - "--csi-address=/run/topolvm/csi-topolvm.sock"

--- a/e2e/hook-secret.yml.template
+++ b/e2e/hook-secret.yml.template
@@ -18,6 +18,7 @@ webhooks:
         namespace: topolvm-system
         name: topolvm-hook
         path: /mutate
+    matchPolicy: Equivalent
     rules:
       - operations: ["CREATE"]
         apiGroups: [""]

--- a/e2e/topolvm-cluster.yaml
+++ b/e2e/topolvm-cluster.yaml
@@ -3,10 +3,7 @@ apiVersion: kind.sigs.k8s.io/v1alpha3
 # patch the generated kubeadm config with some extra settings
 kubeadmConfigPatches:
 - |
-  # When update to Kubernetes 1.15, make sure to change the
-  # apiVersion to "kubeadm.k8s.io/v1beta2".  Also make sure
-  # to change the node image in Makefile (--image kindest/node)
-  apiVersion: kubeadm.k8s.io/v1beta1
+  apiVersion: kubeadm.k8s.io/v1beta2
   kind: ClusterConfiguration
   metadata:
     name: config

--- a/example/kind/topolvm-cluster.yaml
+++ b/example/kind/topolvm-cluster.yaml
@@ -3,10 +3,7 @@ apiVersion: kind.sigs.k8s.io/v1alpha3
 # patch the generated kubeadm config with some extra settings
 kubeadmConfigPatches:
 - |
-  # When update to Kubernetes 1.15, make sure to change the
-  # apiVersion to "kubeadm.k8s.io/v1beta2".  Also make sure
-  # to change the node image in Makefile (--image kindest/node)
-  apiVersion: kubeadm.k8s.io/v1beta1
+  apiVersion: kubeadm.k8s.io/v1beta2
   kind: ClusterConfiguration
   metadata:
     name: config

--- a/example/mutatingwebhooks.yaml.template
+++ b/example/mutatingwebhooks.yaml.template
@@ -100,6 +100,7 @@ webhooks:
         namespace: topolvm-system
         name: topolvm-hook
         path: /mutate
+    matchPolicy: Equivalent
     rules:
       - operations: ["CREATE"]
         apiGroups: [""]

--- a/hook/config/webhook/manifests.yaml
+++ b/hook/config/webhook/manifests.yaml
@@ -14,6 +14,7 @@ webhooks:
       path: /mutate
   failurePolicy: Fail
   name: topolvm-hook
+  matchPolicy: Equivalent
   rules:
   - apiGroups:
     - ""

--- a/hook/mutate_pod_test.go
+++ b/hook/mutate_pod_test.go
@@ -32,6 +32,7 @@ func setupResources() {
 	wh.Name = "topolvm-hook"
 	_, err = ctrl.CreateOrUpdate(testCtx, k8sClient, wh, func() error {
 		failPolicy := admissionregistrationv1beta1.Fail
+		matchPolicy := admissionregistrationv1beta1.Equivalent
 		urlStr := "https://127.0.0.1:8443/mutate"
 		wh.Webhooks = []admissionregistrationv1beta1.MutatingWebhook{
 			{
@@ -41,6 +42,7 @@ func setupResources() {
 					CABundle: caBundle,
 					URL:      &urlStr,
 				},
+				MatchPolicy: &matchPolicy,
 				Rules: []admissionregistrationv1beta1.RuleWithOperations{
 					{
 						Operations: []admissionregistrationv1beta1.OperationType{

--- a/topolvm-node/config/crd/bases/topolvm.cybozu.com_logicalvolumes.yaml
+++ b/topolvm-node/config/crd/bases/topolvm.cybozu.com_logicalvolumes.yaml
@@ -10,6 +10,7 @@ spec:
   names:
     kind: LogicalVolume
     plural: logicalvolumes
+  preserveUnknownFields: false
   scope: Namespaced
   subresources:
     status: {}

--- a/topolvm-node/config/crd/bases/topolvm.cybozu.com_logicalvolumes.yaml
+++ b/topolvm-node/config/crd/bases/topolvm.cybozu.com_logicalvolumes.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/topolvm-node/config/crd/bases/topolvm.cybozu.com_logicalvolumes.yaml
+++ b/topolvm-node/config/crd/bases/topolvm.cybozu.com_logicalvolumes.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null

--- a/topolvm-node/config/crd/patches/webhook_in_logicalvolume.yaml
+++ b/topolvm-node/config/crd/patches/webhook_in_logicalvolume.yaml
@@ -1,5 +1,5 @@
 # The following patch enables conversion webhook for CRDw
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/topolvm-node/config/crd/patches/webhook_in_logicalvolume.yaml
+++ b/topolvm-node/config/crd/patches/webhook_in_logicalvolume.yaml
@@ -1,5 +1,5 @@
 # The following patch enables conversion webhook for CRDw
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:


### PR DESCRIPTION
To update topolvm to apply Kubernetes 1.15, this pull request made the following changes.

- Add `preserveUnknownFields: false` to CRDs in order to use `apiextensions.k8.io/v1` in future 
- Update sidecar containers for TopoLVM
- Use matchPolicy: Equivalent for webhook configurations in e2e-test for TopoLVM

