### PR TITLE
remove unnecessary labels

### DIFF
--- a/e2e/hook-secret.yml.template
+++ b/e2e/hook-secret.yml.template
@@ -8,7 +8,7 @@ webhooks:
   - name: hook.topolvm.cybozu.com
     namespaceSelector:
       matchExpressions:
-      - key: name
+      - key: app.kubernetes.io/name
         operator: NotIn
         values: ["topolvm-system"]
     failurePolicy: Fail

--- a/e2e/namespace.yml
+++ b/e2e/namespace.yml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: topolvm-system
   labels:
-    name: topolvm-system
+    app.kubernetes.io/name: topolvm-system


### PR DESCRIPTION
This pull request made the following change.

- replace `name: topolvm-system` to `app.kubernetes.io/name: topolvm-system` in namespace `topolvm-system` as `MutatingWebhookConfiguration` misconfigured and did not ignore namespace `topolvm-system`. 
- fix `hook-secret.yml.template` as the labels attached to namespace `topolvm-system` changed