### PR TITLE
Upgrade `kind` version in example

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -3,7 +3,8 @@ GOFLAGS=-mod=vendor
 export GOFLAGS
 GINKGO=$(GOPATH)/bin/ginkgo
 KUBECTL=/usr/local/bin/kubectl
-KUBERNETES_VERSION=1.14.3
+KUBERNETES_VERSION=1.15.3
+KIND_VERSION=0.5.1
 
 GO_FILES := $(shell find .. -path ../vendor -prune -o -path ../e2e -prune -o -name '*.go' -print)
 CA_FILES=./build/certs/ca.csr ./build/certs/ca.pem ./build/certs/ca-key.pem
@@ -27,7 +28,7 @@ run: mutatingwebhooks.yaml $(SERVER_CERT_FILES)
 	$(KUBECTL) apply -f build
 
 setup: $(KUBECTL)
-	cd /tmp; env GOFLAGS= GO111MODULE=on go get sigs.k8s.io/kind@v0.4.0
+	cd /tmp; env GOFLAGS= GO111MODULE=on go get sigs.k8s.io/kind@v$(KIND_VERSION)
 	go install github.com/cloudflare/cfssl/cmd/cfssl
 	go install github.com/cloudflare/cfssl/cmd/cfssljson
 	$(SUDO) apt-get update

--- a/example/kind/topolvm-cluster.yaml
+++ b/example/kind/topolvm-cluster.yaml
@@ -3,7 +3,7 @@ apiVersion: kind.sigs.k8s.io/v1alpha3
 # patch the generated kubeadm config with some extra settings
 kubeadmConfigPatches:
 - |
-  apiVersion: kubeadm.k8s.io/v1beta2
+  apiVersion: kubeadm.k8s.io/v1beta1
   kind: ClusterConfiguration
   metadata:
     name: config

--- a/example/kind/topolvm-cluster.yaml
+++ b/example/kind/topolvm-cluster.yaml
@@ -3,7 +3,7 @@ apiVersion: kind.sigs.k8s.io/v1alpha3
 # patch the generated kubeadm config with some extra settings
 kubeadmConfigPatches:
 - |
-  apiVersion: kubeadm.k8s.io/v1beta1
+  apiVersion: kubeadm.k8s.io/v1beta2
   kind: ClusterConfiguration
   metadata:
     name: config


### PR DESCRIPTION
When upgrading Kubernetes from 1.14 to 1.15, we updated apiVersion of `ClusterConfiguration` from `kubeadm.k8s.io/v1beta1` to `kubeadm.k8s.io/v1beta2` with `kind` upgrade from v0.4.0 to v0.5.1

Unfortunately, `topolvm` example is still using `kind` v0.4.0 and it can not use `kubeadm.k8s.io/v1beta2` of `ClusterConfiguration`.
So currently, example is not working.

Thus this pull request made the following change.
- upgrade `kind` version from v0.4.0 to v0.5.1