### PR TITLE
Fix GetCapacity() does not read node labels

### DIFF
--- a/driver/k8s/logical_volume.go
+++ b/driver/k8s/logical_volume.go
@@ -243,7 +243,7 @@ func (s *logicalVolumeService) GetCapacity(ctx context.Context, requestNodeNumbe
 	}
 
 	for _, node := range nl.Items {
-		if nodeNumber, ok := node.Annotations[topolvm.TopologyNodeKey]; ok {
+		if nodeNumber, ok := node.Labels[topolvm.TopologyNodeKey]; ok {
 			if requestNodeNumber != nodeNumber {
 				continue
 			}


### PR DESCRIPTION
Ref: https://kubernetes-csi.github.io/docs/csi-node-object.html

> The CSI GetNodeInfo call returns a set of keys/values labels identifying the topology of that node.
> It stores the key/values as labels on the Kubernetes node object.