### PR TITLE
example: Extend the timeout for waiting for the startup topolvm-controller

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -18,7 +18,7 @@ run: $(SERVER_CERT_FILES)
 	$(MAKE) start-lvmd
 	$(MAKE) launch-kind
 	$(KUBECTL) apply -k .
-	$(KUBECTL) wait --for=condition=available --timeout=60s -n topolvm-system deployments/controller
+	$(KUBECTL) wait --for=condition=available --timeout=120s -n topolvm-system deployments/controller
 	$(KUBECTL) apply -f podpvc.yaml
 
 setup: $(KUBECTL)


### PR DESCRIPTION
ref: #87 