### PR TITLE
webhook: Fix to allow creating Pods before their PVCs

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -11,3 +11,12 @@ Ref: https://kubernetes.io/docs/concepts/storage/volumes/#csi
 
 > The `csi` volume type does not support direct reference from Pod and may
 > only be referenced in a Pod via a `PersistentVolumeClaim` object. 
+
+Pod without PVC
+---------------
+
+TopoLVM expects that PVCs are created in advance of their Pods.
+However, the TopoLVM webhook does not prevent the creation of Pods before their PVCs. This is because such usages are valid in other StorageClasses and the webhook cannot identify the StorageClasses without PVCs.
+TopoLVM does not care about the created pods without their PVCs even if the PVCs are deployed afterward.
+
+The typical usage of TopoLVM is using StatefulSet with volumeClaimTemplate.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -16,7 +16,8 @@ Pod without PVC
 ---------------
 
 TopoLVM expects that PVCs are created in advance of their Pods.
-However, the TopoLVM webhook does not prevent the creation of Pods before their PVCs. This is because such usages are valid in other StorageClasses and the webhook cannot identify the StorageClasses without PVCs.
-TopoLVM does not care about the created pods without their PVCs even if the PVCs are deployed afterward.
+However, the TopoLVM webhook does not block the creation of a Pod when there are missing PVCs for the Pod.
+This is because such usages are valid in other StorageClasses and the webhook cannot identify the StorageClasses without PVCs.
+For such Pods, TopoLVM's extended scheduler will not work.
 
 The typical usage of TopoLVM is using StatefulSet with volumeClaimTemplate.

--- a/hook/mutate_pod_test.go
+++ b/hook/mutate_pod_test.go
@@ -105,14 +105,15 @@ func testPod() *corev1.Pod {
 	return pod
 }
 
-func getPod() (*corev1.Pod, error) {
+func getPod() *corev1.Pod {
 	pod := &corev1.Pod{}
 	name := types.NamespacedName{
 		Namespace: mutatePodNamespace,
 		Name:      defaultPodName,
 	}
 	err := k8sClient.Get(testCtx, name, pod)
-	return pod, err
+	ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
+	return pod
 }
 
 var _ = Describe("pod mutation webhook", func() {
@@ -129,8 +130,7 @@ var _ = Describe("pod mutation webhook", func() {
 		err := k8sClient.Create(testCtx, pod)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		pod, err = getPod()
-		Expect(err).ShouldNot(HaveOccurred())
+		pod = getPod()
 		Expect(pod.Spec.Containers[0].Resources.Requests).To(BeEmpty())
 		Expect(pod.Spec.Containers[0].Resources.Limits).To(BeEmpty())
 	})
@@ -162,8 +162,7 @@ var _ = Describe("pod mutation webhook", func() {
 		err := k8sClient.Create(testCtx, pod)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		pod, err = getPod()
-		Expect(err).ShouldNot(HaveOccurred())
+		pod = getPod()
 		request := pod.Spec.Containers[0].Resources.Requests["topolvm.cybozu.com/capacity"]
 		limit := pod.Spec.Containers[0].Resources.Limits["topolvm.cybozu.com/capacity"]
 		Expect(request.Value()).Should(BeNumerically("==", 1<<30))
@@ -188,8 +187,7 @@ var _ = Describe("pod mutation webhook", func() {
 		err := k8sClient.Create(testCtx, pod)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		pod, err = getPod()
-		Expect(err).ShouldNot(HaveOccurred())
+		pod = getPod()
 		request := pod.Spec.Containers[0].Resources.Requests["topolvm.cybozu.com/capacity"]
 		limit := pod.Spec.Containers[0].Resources.Limits["topolvm.cybozu.com/capacity"]
 		Expect(request.Value()).Should(BeNumerically("==", 2<<30))
@@ -214,8 +212,7 @@ var _ = Describe("pod mutation webhook", func() {
 		err := k8sClient.Create(testCtx, pod)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		pod, err = getPod()
-		Expect(err).ShouldNot(HaveOccurred())
+		pod = getPod()
 		request := pod.Spec.Containers[0].Resources.Requests["topolvm.cybozu.com/capacity"]
 		limit := pod.Spec.Containers[0].Resources.Limits["topolvm.cybozu.com/capacity"]
 		Expect(request.Value()).Should(BeNumerically("==", 1<<30))
@@ -241,8 +238,7 @@ var _ = Describe("pod mutation webhook", func() {
 		err := k8sClient.Create(testCtx, pod)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		pod, err = getPod()
-		Expect(err).ShouldNot(HaveOccurred())
+		pod = getPod()
 		request := pod.Spec.Containers[0].Resources.Requests["topolvm.cybozu.com/capacity"]
 		limit := pod.Spec.Containers[0].Resources.Limits["topolvm.cybozu.com/capacity"]
 		Expect(request.Value()).Should(BeNumerically("==", 1<<30))
@@ -273,8 +269,7 @@ var _ = Describe("pod mutation webhook", func() {
 		err := k8sClient.Create(testCtx, pod)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		pod, err = getPod()
-		Expect(err).ShouldNot(HaveOccurred())
+		pod = getPod()
 		Expect(pod.Spec.Containers[0].Resources.Requests).To(BeEmpty())
 		Expect(pod.Spec.Containers[0].Resources.Limits).To(BeEmpty())
 	})
@@ -304,8 +299,7 @@ var _ = Describe("pod mutation webhook", func() {
 		err := k8sClient.Create(testCtx, pod)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		pod, err = getPod()
-		Expect(err).ShouldNot(HaveOccurred())
+		pod = getPod()
 		request := pod.Spec.Containers[0].Resources.Requests["topolvm.cybozu.com/capacity"]
 		Expect(request.Value()).Should(BeNumerically("==", 3<<30))
 	})
@@ -323,8 +317,7 @@ var _ = Describe("pod mutation webhook", func() {
 		err := k8sClient.Create(testCtx, pod)
 		Expect(err).ShouldNot(HaveOccurred())
 
-		pod, err = getPod()
-		Expect(err).ShouldNot(HaveOccurred())
+		pod = getPod()
 		Expect(pod.Spec.Containers[0].Resources.Requests).To(BeEmpty())
 		Expect(pod.Spec.Containers[0].Resources.Limits).To(BeEmpty())
 	})


### PR DESCRIPTION
As creating Pods before their PVCs is a valid behavior in other StorageClasses, we modified the TopoLVM webhook to allow the behavior in this pull request.

Along with this change, we updated `limitation.md`.