### PR TITLE
Tweak

### DIFF
--- a/controllers/node_controller.go
+++ b/controllers/node_controller.go
@@ -103,7 +103,7 @@ func (r *NodeReconciler) doFinalize(ctx context.Context, log logr.Logger, node *
 	}
 
 	var pvcs corev1.PersistentVolumeClaimList
-	err = r.List(ctx, &pvcs, client.MatchingField(KeySelectedNode, node.Name))
+	err = r.List(ctx, &pvcs, client.MatchingFields{KeySelectedNode: node.Name})
 	if err != nil {
 		log.Error(err, "unable to fetch PersistentVolumeClaimList")
 		return ctrl.Result{}, err

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -33,7 +33,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/driver/node.go
+++ b/driver/node.go
@@ -79,12 +79,12 @@ func (s *nodeService) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	if req.GetVolumeCapability() == nil {
 		return nil, status.Error(codes.InvalidArgument, "no volume_capability is provided")
 	}
-	isBlockVol := (req.GetVolumeCapability().GetBlock() != nil)
-	isFsVol := (req.GetVolumeCapability().GetMount() != nil)
+	isBlockVol := req.GetVolumeCapability().GetBlock() != nil
+	isFsVol := req.GetVolumeCapability().GetMount() != nil
 	if !(isBlockVol || isFsVol) {
 		return nil, status.Errorf(codes.InvalidArgument, "no supported volume capability: %v", req.GetVolumeCapability())
 	}
-	isInlineEphemeralVolumeReq := (volumeContext[ephVolConKey] == "true")
+	isInlineEphemeralVolumeReq := volumeContext[ephVolConKey] == "true"
 
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -309,14 +309,14 @@ spec:
 				}
 				strCap, ok := node.Annotations[topolvm.CapacityKey]
 				Expect(ok).To(Equal(true), "capacity is not annotated: "+node.Name)
-				cap, err := strconv.Atoi(strCap)
+				capacity, err := strconv.Atoi(strCap)
 				Expect(err).ShouldNot(HaveOccurred())
-				fmt.Printf("%s: %d bytes\n", node.Name, cap)
+				fmt.Printf("%s: %d bytes\n", node.Name, capacity)
 				switch {
-				case cap > maxCapacity:
-					maxCapacity = cap
+				case capacity > maxCapacity:
+					maxCapacity = capacity
 					maxCapNodes = []string{node.GetName()}
-				case cap == maxCapacity:
+				case capacity == maxCapacity:
 					maxCapNodes = append(maxCapNodes, node.GetName())
 				}
 			}
@@ -586,12 +586,12 @@ spec:
 
 			strCap, ok := node.Annotations[topolvm.CapacityKey]
 			Expect(ok).To(Equal(true), "capacity is not annotated: "+node.Name)
-			cap, err := strconv.Atoi(strCap)
+			capacity, err := strconv.Atoi(strCap)
 			Expect(err).ShouldNot(HaveOccurred())
 
-			fmt.Printf("%s: %d\n", node.Name, cap)
-			if cap > maxCapacity {
-				maxCapacity = cap
+			fmt.Printf("%s: %d\n", node.Name, capacity)
+			if capacity > maxCapacity {
+				maxCapacity = capacity
 				targetNode = node.Name
 			}
 		}
@@ -810,7 +810,7 @@ func verifyMountProperties(ns string, pod string, mount string, fsType string, s
 	stdout, stderr, err = kubectl("exec", "-n", ns, pod, "--", "df", "--output=size", mount)
 	Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
 
-	dfFields := strings.Fields((string(stdout)))
+	dfFields := strings.Fields(string(stdout))
 	volSize, err := strconv.Atoi(dfFields[1])
 	Expect(err).ShouldNot(HaveOccurred())
 	Expect(volSize).To(Equal(size))

--- a/hook/run_test.go
+++ b/hook/run_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func run(stopCh <-chan struct{}, cfg *rest.Config, scheme *runtime.Scheme, webhookHost string, webhookPort int) error {
-	ctrl.SetLogger(zap.Logger(true))
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	certDir, err := filepath.Abs("./testdata")
 	if err != nil {

--- a/hook/suite_test.go
+++ b/hook/suite_test.go
@@ -139,7 +139,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
 
 	By("bootstrapping test environment")
 	apiServerFlags := envtest.DefaultKubeAPIServerFlags[0 : len(envtest.DefaultKubeAPIServerFlags)-1]

--- a/pkg/topolvm-controller/cmd/run.go
+++ b/pkg/topolvm-controller/cmd/run.go
@@ -46,7 +46,7 @@ func init() {
 
 // Run builds and starts the manager with leader election.
 func subMain() error {
-	ctrl.SetLogger(zap.Logger(config.development))
+	ctrl.SetLogger(zap.New(zap.UseDevMode(config.development)))
 
 	cfg, err := ctrl.GetConfig()
 	if err != nil {

--- a/pkg/topolvm-node/cmd/run.go
+++ b/pkg/topolvm-node/cmd/run.go
@@ -48,7 +48,7 @@ func subMain() error {
 		return errors.New("Node name is not given")
 	}
 
-	ctrl.SetLogger(zap.Logger(config.development))
+	ctrl.SetLogger(zap.New(zap.UseDevMode(config.development)))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,


### PR DESCRIPTION
- Stop to use deprecated methods: `LoggerTo`, `MatchingField`
- Remove unnecessary wrapping
- Rename "cap" to "capacity" since "cap" is reserved

Signed-off-by: dulltz <isrgnoe@gmail.com>