### PR TITLE
Use larger resource class for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ jobs:
   e2e-k8s-v1_17:
     machine:
       image: ubuntu-1604:201903-01
+    resource_class: large
     working_directory: /home/circleci/work
     steps:
       - checkout
@@ -127,6 +128,7 @@ jobs:
   e2e-k8s-v1_16:
     machine:
       image: ubuntu-1604:201903-01
+    resource_class: large
     working_directory: /home/circleci/work
     steps:
       - checkout
@@ -135,6 +137,7 @@ jobs:
   e2e-k8s-v1_15:
     machine:
       image: ubuntu-1604:201903-01
+    resource_class: large
     working_directory: /home/circleci/work
     steps:
       - checkout


### PR DESCRIPTION
e2e-k8s-* jobs rarely fails at https://github.com/cybozu-go/topolvm/blob/381de025e0045d2da48abafb83ef2dd8dc660d9f/e2e/cleanup_test.go#L214 , due to timeout.

```
TopoLVM cleanup 
  should finalize the delete node
  /home/circleci/work/e2e/cleanup_test.go:27
STEP: checking Node finalizer
created namespace: cleanup-test
STEP: applying statefulset
STEP: getting target pvcs/pods
STEP: setting unschedule flag to Node kind-worker3
STEP: deleting topolvm-node pod
STEP: deleting Node kind-worker3
STEP: confirming pvc/pod are deleted and recreated

• Failure [76.484 seconds]
TopoLVM
/home/circleci/work/e2e/suite_test.go:99
  cleanup
  /home/circleci/work/e2e/suite_test.go:106
    should finalize the delete node [It]
    /home/circleci/work/e2e/cleanup_test.go:27

    Timed out after 60.000s.
    Expected success, but got an error:
        <*errors.errorString | 0xc000261560>: {
            s: "pvc is not deleted. uid: 26fc3533-09df-44f6-86d8-87b2d43eed9b",
        }
        pvc is not deleted. uid: 26fc3533-09df-44f6-86d8-87b2d43eed9b

    /home/circleci/work/e2e/cleanup_test.go:214
```

According to https://circleci.com/docs/2.0/configuration-reference/#machine-executor-linux , these jobs uses "medium" class VM with 2 cores and 8GB memory. We have also run e2e test on local VMs and we have found that it sometimes fails on a poor VM (4 cores, 3GB) and never fails on a rich VM (8 cores, 24GB). So we suspect that the failure is caused by low machine spec.

Signed-off-by: UMEZAWA Takeshi <takeshi-umezawa@cybozu.co.jp>